### PR TITLE
Users editing and start of assistant permissions functionality

### DIFF
--- a/backend/List/List.Users/Controllers/AssistantPermissionsController.cs
+++ b/backend/List/List.Users/Controllers/AssistantPermissionsController.cs
@@ -1,0 +1,71 @@
+using List.Users.Data;
+using List.Users.DTOs;
+using List.Users.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace List.Users.Controllers;
+
+[ApiController]
+[Route("api/assistant-permissions")]
+public class AssistantPermissionsController(UsersDbContext context) : ControllerBase
+{
+    private readonly UsersDbContext _context = context;
+
+    [HttpGet("{userId:int}")]
+    public async Task<ActionResult<AssistantPermissionsDto>> GetPermissions(int userId)
+    {
+        var permissions = await _context.AssistantPermissions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == userId);
+
+        if (permissions == null)
+        {
+            return Ok(new AssistantPermissionsDto { UserId = userId });
+        }
+
+        return Ok(new AssistantPermissionsDto
+        {
+            UserId = permissions.UserId,
+            CanAddStudents = permissions.CanAddStudents,
+            CanManageStudents = permissions.CanManageStudents,
+            CanManageTaskTypes = permissions.CanManageTaskTypes,
+            CanManagePeriods = permissions.CanManagePeriods,
+            CanManageCategories = permissions.CanManageCategories,
+            CanViewLogs = permissions.CanViewLogs
+        });
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> SavePermissions([FromBody] AssistantPermissionsDto dto)
+    {
+        var existing = await _context.AssistantPermissions
+            .FirstOrDefaultAsync(p => p.UserId == dto.UserId);
+
+        if (existing != null)
+        {
+            existing.CanAddStudents = dto.CanAddStudents;
+            existing.CanManageStudents = dto.CanManageStudents;
+            existing.CanManageTaskTypes = dto.CanManageTaskTypes;
+            existing.CanManagePeriods = dto.CanManagePeriods;
+            existing.CanManageCategories = dto.CanManageCategories;
+            existing.CanViewLogs = dto.CanViewLogs;
+        }
+        else
+        {
+            _context.AssistantPermissions.Add(new AssistantPermissions
+            {
+                UserId = dto.UserId,
+                CanAddStudents = dto.CanAddStudents,
+                CanManageStudents = dto.CanManageStudents,
+                CanManageTaskTypes = dto.CanManageTaskTypes,
+                CanManagePeriods = dto.CanManagePeriods,
+                CanManageCategories = dto.CanManageCategories,
+                CanViewLogs = dto.CanViewLogs
+            });
+        }
+
+        await _context.SaveChangesAsync();
+        return Ok();
+    }
+}

--- a/backend/List/List.Users/DTOs/AssistantPermissionsDto.cs
+++ b/backend/List/List.Users/DTOs/AssistantPermissionsDto.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using List.Users.Models;
+
+namespace List.Users.DTOs;
+
+public class AssistantPermissionsDto
+{
+    public int UserId { get; set; }
+
+    public bool CanAddStudents { get; set; } = false;
+    public bool CanManageStudents { get; set; } = false;
+    public bool CanManageTaskTypes { get; set; } = false;
+    public bool CanManagePeriods { get; set; } = false;
+    public bool CanManageCategories { get; set; } = false;
+    public bool CanViewLogs { get; set; } = false;
+}

--- a/backend/List/List.Users/DTOs/UserUpdateDto.cs
+++ b/backend/List/List.Users/DTOs/UserUpdateDto.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using List.Users.Models;
+
+namespace List.Users.DTOs;
+
+public class UserUpdateDto
+{
+    [Required]
+    public string FullName { get; set; }
+
+    [Required, EmailAddress]
+    public string Email { get; set; }
+
+    [Required, JsonConverter(typeof(JsonStringEnumConverter))]
+    public UserRole Role { get; set; }
+}

--- a/backend/List/List.Users/Data/UsersDbContext.cs
+++ b/backend/List/List.Users/Data/UsersDbContext.cs
@@ -7,6 +7,8 @@ namespace List.Users.Data;
 public class UsersDbContext(DbContextOptions<UsersDbContext> options) : DbContext(options)
 {
     public DbSet<User> Users { get; set; }
+    public DbSet<AssistantPermissions> AssistantPermissions { get; set; }
+
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/List/List.Users/Migrations/20250526023252_AssistantPermissions.Designer.cs
+++ b/backend/List/List.Users/Migrations/20250526023252_AssistantPermissions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using List.Users.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace List.Users.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250526023252_AssistantPermissions")]
+    partial class AssistantPermissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/List/List.Users/Migrations/20250526023252_AssistantPermissions.cs
+++ b/backend/List/List.Users/Migrations/20250526023252_AssistantPermissions.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace List.Users.Migrations
+{
+    /// <inheritdoc />
+    public partial class AssistantPermissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "assistant_permissions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    can_add_students = table.Column<bool>(type: "boolean", nullable: false),
+                    can_manage_students = table.Column<bool>(type: "boolean", nullable: false),
+                    can_manage_task_types = table.Column<bool>(type: "boolean", nullable: false),
+                    can_manage_periods = table.Column<bool>(type: "boolean", nullable: false),
+                    can_manage_categories = table.Column<bool>(type: "boolean", nullable: false),
+                    can_view_logs = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_assistant_permissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_assistant_permissions_Users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_assistant_permissions_user_id",
+                table: "assistant_permissions",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "assistant_permissions");
+        }
+    }
+}

--- a/backend/List/List.Users/Models/AssistantPermissions.cs
+++ b/backend/List/List.Users/Models/AssistantPermissions.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace List.Users.Models;
+
+[Table("assistant_permissions")]
+public class AssistantPermissions
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    [Column("user_id")]
+    public int UserId { get; set; }
+
+    [ForeignKey("UserId")]
+    public User User { get; set; }
+
+    [Column("can_add_students")]
+    public bool CanAddStudents { get; set; } = true;
+
+    [Column("can_manage_students")]
+    public bool CanManageStudents { get; set; } = true;
+
+    [Column("can_manage_task_types")]
+    public bool CanManageTaskTypes { get; set; } = true;
+
+    [Column("can_manage_periods")]
+    public bool CanManagePeriods { get; set; } = true;
+
+    [Column("can_manage_categories")]
+    public bool CanManageCategories { get; set; } = true;
+
+    [Column("can_view_logs")]
+    public bool CanViewLogs { get; set; } = true;
+}

--- a/backend/List/List.Users/Module.cs
+++ b/backend/List/List.Users/Module.cs
@@ -16,6 +16,7 @@ public class Module : IModule
                 options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
         
         services.AddScoped<IUserService, UserService>();
+        services.AddScoped<IAssistantPermissionService, AssistantPermissionService>();
     }
 
     public void UseServices(IApplicationBuilder app)

--- a/backend/List/List.Users/Services/AssistantPermissionsService.cs
+++ b/backend/List/List.Users/Services/AssistantPermissionsService.cs
@@ -1,0 +1,24 @@
+using List.Users.Data;
+using List.Users.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace List.Users.Services;
+
+public class AssistantPermissionService : IAssistantPermissionService
+{
+    private readonly UsersDbContext _context;
+
+    public AssistantPermissionService(UsersDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<bool> HasPermissionAsync(int userId, Func<AssistantPermissions, bool> permissionSelector)
+    {
+        var permissions = await _context.AssistantPermissions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == userId);
+
+        return permissions != null && permissionSelector(permissions);
+    }
+}

--- a/backend/List/List.Users/Services/IAssistantPermissionService.cs
+++ b/backend/List/List.Users/Services/IAssistantPermissionService.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+using List.Users.Models;
+
+namespace List.Users.Services;
+
+public interface IAssistantPermissionService
+{
+    Task<bool> HasPermissionAsync(int userId, Func<AssistantPermissions, bool> permissionSelector);
+}

--- a/backend/List/List.Users/Services/IUserService.cs
+++ b/backend/List/List.Users/Services/IUserService.cs
@@ -12,4 +12,5 @@ public interface IUserService
     public Task<bool> AddOrUpdateUserAsync(User user);
     public Task<bool> DeleteUserAsync(int userId);
     public Task<bool> IsUserExistsAsync(User user);
+    public Task<bool> UpdateUserAsync(User user);
 }

--- a/backend/List/List.Users/Services/UserService.cs
+++ b/backend/List/List.Users/Services/UserService.cs
@@ -73,4 +73,18 @@ public class UserService(UsersDbContext context) : IUserService
         .Where(u => u.Role == 0)
         .ToListAsync();
     }
+
+    public async Task<bool> UpdateUserAsync(User user)
+    {
+        try
+        {
+            context.Users.Update(user);
+            await context.SaveChangesAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/frontend/src/modules/Authentication/components/AssistantRoleSelector.tsx
+++ b/frontend/src/modules/Authentication/components/AssistantRoleSelector.tsx
@@ -1,0 +1,40 @@
+
+import {
+    Dialog,
+    DialogContent,
+    DialogActions,
+    Typography,
+    Button,
+    Stack
+} from '@mui/material';
+
+type Props = {
+    open: boolean;
+    onSelectStudent: () => void;
+    onSelectTeacher: () => void;
+};
+
+const AssistantRoleSelector = ({ open, onSelectStudent, onSelectTeacher }: Props) => {
+    return (
+        <Dialog open={open}>
+            <DialogContent sx={{ textAlign: 'center', px: 4, pt: 3, pb: 4 }}>
+                <Typography variant="h6" fontWeight="bold" sx={{ mb: 3 }}>
+                    Pokračovať ako:
+                </Typography>
+                <Stack spacing={2}>
+                    <Button variant="contained" size="large" fullWidth onClick={onSelectStudent}>
+                        Študent
+                    </Button>
+                    <Button variant="outlined" size="large" color = "secondary" fullWidth onClick={onSelectTeacher}>
+                        Učiteľ
+                    </Button>
+                </Stack>
+            </DialogContent>
+
+
+            <DialogActions sx={{ display: 'none' }} />
+        </Dialog>
+    );
+};
+
+export default AssistantRoleSelector;

--- a/frontend/src/modules/Users/components/AssistantScopeDialog.tsx
+++ b/frontend/src/modules/Users/components/AssistantScopeDialog.tsx
@@ -1,0 +1,106 @@
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Typography,
+    FormGroup,
+    FormControlLabel,
+    Checkbox
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { User } from "../types/User.ts";
+import { AssistantPermissions } from "../types/AssistantPermissions.ts";
+import { useNotification } from "../../../shared/components/NotificationContext.tsx";
+import api from "../../../services/api.ts";
+
+type Props = {
+    open: boolean;
+    user: User | null;
+    onClose: () => void;
+};
+
+const defaultPermissions = (userId: number): AssistantPermissions => ({
+    userId,
+    canAddStudents: false,
+    canManageStudents: false,
+    canManageTaskTypes: false,
+    canManagePeriods: false,
+    canManageCategories: false,
+    canViewLogs: false
+});
+
+export const AssistantScopeDialog = ({ open, onClose, user }: Props) => {
+    const [permissions, setPermissions] = useState<AssistantPermissions | null>(null);
+    const { showNotification } = useNotification();
+
+    useEffect(() => {
+        if (open && user) {
+            api.get(`/assistant-permissions/${user.id}`)
+                .then(res => setPermissions(res.data))
+                .catch(() => setPermissions(defaultPermissions(user.id)));
+        }
+    }, [open, user]);
+
+    const handleChange = (field: keyof AssistantPermissions) => (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (!permissions) return;
+        setPermissions({ ...permissions, [field]: e.target.checked });
+    };
+
+    const handleSave = async () => {
+        if (!permissions) return;
+        try {
+            await api.post("/assistant-permissions", permissions);
+            showNotification("Práva asistenta boli uložené", "success");
+            onClose();
+        } catch (err) {
+            console.error(err);
+            showNotification("Nepodarilo sa uložiť práva asistenta", "error");
+        }
+    };
+
+    return (
+        <Dialog fullWidth open={open} onClose={onClose}>
+            <DialogTitle>Nastavenie práv asistenta</DialogTitle>
+            <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                <Typography gutterBottom>
+                    Práva asistenta pre: <b>{user?.fullname}</b>
+                </Typography>
+
+                {permissions && (
+                    <FormGroup>
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canAddStudents} onChange={handleChange("canAddStudents")} />}
+                            label="Môže pridávať študentov"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canManageStudents} onChange={handleChange("canManageStudents")} />}
+                            label="Môže upravovať a mazať študentov"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canManageTaskTypes} onChange={handleChange("canManageTaskTypes")} />}
+                            label="Môže spravovať typy úloh"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canManagePeriods} onChange={handleChange("canManagePeriods")} />}
+                            label="Môže spravovať obdobia"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canManageCategories} onChange={handleChange("canManageCategories")} />}
+                            label="Môže spravovať kategórie"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox checked={permissions.canViewLogs} onChange={handleChange("canViewLogs")} />}
+                            label="Môže zobrazovať logy"
+                        />
+                    </FormGroup>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="inherit">Zrušiť</Button>
+                <Button onClick={handleSave} variant="contained">Uložiť</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/frontend/src/modules/Users/components/EditUserDialog.tsx
+++ b/frontend/src/modules/Users/components/EditUserDialog.tsx
@@ -1,0 +1,80 @@
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControlLabel,
+    FormLabel,
+    Radio,
+    RadioGroup,
+    TextField
+} from "@mui/material";
+import { User } from "../types/User";
+import { useState, useEffect } from "react";
+
+type Props = {
+    isOpen: boolean;
+    user: User | null;
+    onSubmit: (updatedUser: User) => void;
+    onClose: () => void;
+};
+
+export const EditUserDialog = ({ isOpen, user, onSubmit, onClose }: Props) => {
+    const [fullName, setFullName] = useState("");
+    const [email, setEmail] = useState("");
+    const [role, setRole] = useState<User["role"]>("Student");
+
+    useEffect(() => {
+        if (user) {
+            setFullName(user.fullname);
+            setEmail(user.email);
+            setRole(user.role);
+        }
+    }, [user]);
+
+    if (!user) return null;
+
+    return (
+        <Dialog fullWidth open={isOpen} onClose={onClose}>
+            <DialogTitle>Upraviť používateľa</DialogTitle>
+            <DialogContent dividers sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+                <TextField
+                    label="Meno a priezvisko"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                    required
+                />
+                <TextField
+                    label="E-mail"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                />
+                <FormLabel>Rola</FormLabel>
+                <RadioGroup
+                    name="role"
+                    value={role}
+                    onChange={(e) => setRole(e.target.value as User["role"])}
+                >
+                    <FormControlLabel value="Teacher" control={<Radio />} label="Teacher" />
+                    <FormControlLabel value="Assistant" control={<Radio />} label="Assistant" />
+                    <FormControlLabel value="Student" control={<Radio />} label="Student" />
+                </RadioGroup>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} variant="text" color="warning">Zrušiť</Button>
+                <Button
+                    onClick={() => {
+                        onSubmit({ ...user, fullname: fullName, email, role });
+                        onClose();
+                    }}
+                    variant="contained"
+                >
+                    Uložiť zmeny
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/frontend/src/modules/Users/types/AssistantPermissions.ts
+++ b/frontend/src/modules/Users/types/AssistantPermissions.ts
@@ -1,0 +1,9 @@
+export type AssistantPermissions = {
+    userId: number;
+    canAddStudents: boolean;
+    canManageStudents: boolean;
+    canManageTaskTypes: boolean;
+    canManagePeriods: boolean;
+    canManageCategories: boolean;
+    canViewLogs: boolean;
+};


### PR DESCRIPTION
Add option to edit users email name and role
Added component to edit assistant permissions, also automatically displayed after creating an assistant or editing role to assistant added table assistent_permissions

On login of assistant a can choose to log as student or teacher